### PR TITLE
Fixed letter capitalization in the About tab (pl)

### DIFF
--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -261,8 +261,8 @@
     <string name="about_feedback_summary">Wyślij zgłoszenie o błędzie poprzez e-maila</string>
     <string name="about_faq">FAQ</string>
     <string name="about_faq_summary">Zobacz Najczęściej Zadawane Pytania</string>
-    <string name="about_discord">Serwer discord</string>
-    <string name="about_discord_summary">Dołącz do społeczności wulkanowego</string>
+    <string name="about_discord">Serwer Discord</string>
+    <string name="about_discord_summary">Dołącz do społeczności Wulkanowego</string>
     <string name="about_privacy">Polityka prywatności</string>
     <string name="about_privacy_summary">Zasady zbierania danych osobowych</string>
     <string name="about_homepage">Strona domowa</string>


### PR DESCRIPTION
I've capitalized "Discord" and "Wulkanowego" in the polish version of About, as shown here - https://i.fiery.me/9icbq.jpg