### PR TITLE
Fixed capitalization in the about tab (en)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -243,7 +243,7 @@
     <string name="about_faq">FAQ</string>
     <string name="about_faq_summary">Read Frequently Asked Questions</string>
     <string name="about_discord">Discord server</string>
-    <string name="about_discord_summary">Join the wulkanowy community</string>
+    <string name="about_discord_summary">Join the Wulkanowy community</string>
     <string name="about_privacy">Privacy policy</string>
     <string name="about_privacy_summary">Rules for collecting personal data</string>
     <string name="about_homepage">Homepage</string>


### PR DESCRIPTION
Capitalized "Wulkanowy" in the English version of the app (about tab)