### PR TITLE
Changed Wulkanowy API link to Wulkanowy SDK

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -46,7 +46,7 @@ You can also download a [development version](https://wulkanowy.github.io/#downl
 ## Built With
 
 
-* [Wulkanowy API](https://github.com/wulkanowy/api)
+* [Wulkanowy SDK](https://github.com/wulkanowy/sdk)
 * [RxJava 2](https://github.com/ReactiveX/RxJava)
 * [Dagger 2](https://github.com/google/dagger)
 * [Room](https://developer.android.com/topic/libraries/architecture/room)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Możesz także pobrać [wersję rozwojową](https://wulkanowy.github.io/#downloa
 
 ## Zbudowana za pomocą
 
-* [Wulkanowy API](https://github.com/wulkanowy/api)
+* [Wulkanowy SDK](https://github.com/wulkanowy/SDK)
 * [RxJava 2](https://github.com/ReactiveX/RxJava)
 * [Dagger 2](https://github.com/google/dagger)
 * [Room](https://developer.android.com/topic/libraries/architecture/room)


### PR DESCRIPTION
Changed links in README and README.en, because this project has recently switched to Wulkanowy SDK from Wulkanowy API.