### PR TITLE
Replace Creators with Contributors

### DIFF
--- a/app/src/main/java/io/github/wulkanowy/ui/modules/about/AboutFragment.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/about/AboutFragment.kt
@@ -16,7 +16,7 @@ import eu.davidea.flexibleadapter.common.SmoothScrollLinearLayoutManager
 import eu.davidea.flexibleadapter.items.AbstractFlexibleItem
 import io.github.wulkanowy.R
 import io.github.wulkanowy.ui.base.BaseFragment
-import io.github.wulkanowy.ui.modules.about.creator.CreatorFragment
+import io.github.wulkanowy.ui.modules.about.contributor.ContributorFragment
 import io.github.wulkanowy.ui.modules.about.license.LicenseFragment
 import io.github.wulkanowy.ui.modules.about.logviewer.LogViewerFragment
 import io.github.wulkanowy.ui.modules.main.MainActivity
@@ -155,7 +155,7 @@ class AboutFragment : BaseFragment(), AboutView, MainView.TitledView {
     }
 
     override fun openCreators() {
-        (activity as? MainActivity)?.pushView(CreatorFragment.newInstance())
+        (activity as? MainActivity)?.pushView(ContributorFragment.newInstance())
     }
 
     override fun openPrivacyPolicy() {

--- a/app/src/main/java/io/github/wulkanowy/ui/modules/about/contributor/ContributorFragment.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/about/contributor/ContributorFragment.kt
@@ -1,4 +1,4 @@
-package io.github.wulkanowy.ui.modules.about.creator
+package io.github.wulkanowy.ui.modules.about.contributor
 
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -18,10 +18,10 @@ import io.github.wulkanowy.utils.setOnItemClickListener
 import kotlinx.android.synthetic.main.fragment_creator.*
 import javax.inject.Inject
 
-class CreatorFragment : BaseFragment(), CreatorView, MainView.TitledView {
+class ContributorFragment : BaseFragment(), ContributorView, MainView.TitledView {
 
     @Inject
-    lateinit var presenter: CreatorPresenter
+    lateinit var presenter: ContributorPresenter
 
     @Inject
     lateinit var creatorsAdapter: FlexibleAdapter<AbstractFlexibleItem<*>>
@@ -29,7 +29,7 @@ class CreatorFragment : BaseFragment(), CreatorView, MainView.TitledView {
     override val titleStringId get() = R.string.contributors_title
 
     companion object {
-        fun newInstance() = CreatorFragment()
+        fun newInstance() = ContributorFragment()
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -53,7 +53,7 @@ class CreatorFragment : BaseFragment(), CreatorView, MainView.TitledView {
         creatorSeeMore.setOnClickListener { presenter.onSeeMoreClick() }
     }
 
-    override fun updateData(data: List<CreatorItem>) {
+    override fun updateData(data: List<ContributorItem>) {
         creatorsAdapter.updateDataSet(data)
     }
 

--- a/app/src/main/java/io/github/wulkanowy/ui/modules/about/contributor/ContributorItem.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/about/contributor/ContributorItem.kt
@@ -1,4 +1,4 @@
-package io.github.wulkanowy.ui.modules.about.creator
+package io.github.wulkanowy.ui.modules.about.contributor
 
 import android.view.View
 import coil.api.load
@@ -12,7 +12,8 @@ import io.github.wulkanowy.data.pojos.AppCreator
 import kotlinx.android.extensions.LayoutContainer
 import kotlinx.android.synthetic.main.item_creator.*
 
-class CreatorItem(val creator: AppCreator) : AbstractFlexibleItem<CreatorItem.ViewHolder>() {
+class ContributorItem(val creator: AppCreator) :
+    AbstractFlexibleItem<ContributorItem.ViewHolder>() {
 
     override fun getLayoutRes() = R.layout.item_creator
 
@@ -33,7 +34,7 @@ class CreatorItem(val creator: AppCreator) : AbstractFlexibleItem<CreatorItem.Vi
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as CreatorItem
+        other as ContributorItem
 
         if (creator != other.creator) return false
 

--- a/app/src/main/java/io/github/wulkanowy/ui/modules/about/contributor/ContributorPresenter.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/about/contributor/ContributorPresenter.kt
@@ -1,30 +1,28 @@
-package io.github.wulkanowy.ui.modules.about.creator
+package io.github.wulkanowy.ui.modules.about.contributor
 
 import eu.davidea.flexibleadapter.items.AbstractFlexibleItem
-import io.github.wulkanowy.data.pojos.AppCreator
 import io.github.wulkanowy.data.repositories.appcreator.AppCreatorRepository
 import io.github.wulkanowy.data.repositories.student.StudentRepository
 import io.github.wulkanowy.ui.base.BasePresenter
 import io.github.wulkanowy.ui.base.ErrorHandler
 import io.github.wulkanowy.utils.SchedulersProvider
-import io.reactivex.Single
 import javax.inject.Inject
 
-class CreatorPresenter @Inject constructor(
+class ContributorPresenter @Inject constructor(
     schedulers: SchedulersProvider,
     errorHandler: ErrorHandler,
     studentRepository: StudentRepository,
     private val appCreatorRepository: AppCreatorRepository
-) : BasePresenter<CreatorView>(errorHandler, studentRepository, schedulers) {
+) : BasePresenter<ContributorView>(errorHandler, studentRepository, schedulers) {
 
-    override fun onAttachView(view: CreatorView) {
+    override fun onAttachView(view: ContributorView) {
         super.onAttachView(view)
         view.initView()
         loadData()
     }
 
     fun onItemSelected(item: AbstractFlexibleItem<*>) {
-        if (item !is CreatorItem) return
+        if (item !is ContributorItem) return
         view?.openUserGithubPage(item.creator.githubUsername)
     }
 
@@ -34,7 +32,7 @@ class CreatorPresenter @Inject constructor(
 
     private fun loadData() {
         disposable.add(appCreatorRepository.getAppCreators()
-            .map { it.map { creator -> CreatorItem(creator) } }
+            .map { it.map { creator -> ContributorItem(creator) } }
             .subscribeOn(schedulers.backgroundThread)
             .observeOn(schedulers.mainThread)
             .doFinally { view?.showProgress(false) }

--- a/app/src/main/java/io/github/wulkanowy/ui/modules/about/contributor/ContributorView.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/about/contributor/ContributorView.kt
@@ -1,12 +1,12 @@
-package io.github.wulkanowy.ui.modules.about.creator
+package io.github.wulkanowy.ui.modules.about.contributor
 
 import io.github.wulkanowy.ui.base.BaseView
 
-interface CreatorView : BaseView {
+interface ContributorView : BaseView {
 
     fun initView()
 
-    fun updateData(data: List<CreatorItem>)
+    fun updateData(data: List<ContributorItem>)
 
     fun openUserGithubPage(username: String)
 

--- a/app/src/main/java/io/github/wulkanowy/ui/modules/about/creator/CreatorFragment.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/about/creator/CreatorFragment.kt
@@ -26,7 +26,7 @@ class CreatorFragment : BaseFragment(), CreatorView, MainView.TitledView {
     @Inject
     lateinit var creatorsAdapter: FlexibleAdapter<AbstractFlexibleItem<*>>
 
-    override val titleStringId get() = R.string.creators_title
+    override val titleStringId get() = R.string.contributors_title
 
     companion object {
         fun newInstance() = CreatorFragment()

--- a/app/src/main/java/io/github/wulkanowy/ui/modules/main/MainModule.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/main/MainModule.kt
@@ -8,7 +8,7 @@ import dagger.android.ContributesAndroidInjector
 import io.github.wulkanowy.R
 import io.github.wulkanowy.di.scopes.PerFragment
 import io.github.wulkanowy.ui.modules.about.AboutFragment
-import io.github.wulkanowy.ui.modules.about.creator.CreatorFragment
+import io.github.wulkanowy.ui.modules.about.contributor.ContributorFragment
 import io.github.wulkanowy.ui.modules.about.license.LicenseFragment
 import io.github.wulkanowy.ui.modules.about.license.LicenseModule
 import io.github.wulkanowy.ui.modules.about.logviewer.LogViewerFragment
@@ -128,7 +128,7 @@ abstract class MainModule {
 
     @PerFragment
     @ContributesAndroidInjector()
-    abstract fun bindCreatorsFragment(): CreatorFragment
+    abstract fun bindContributorFragment(): ContributorFragment
 
     @PerFragment
     @ContributesAndroidInjector(modules = [SchoolAndTeachersModule::class])

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -15,7 +15,7 @@
     <string name="more_title">Więcej</string>
     <string name="about_title">O aplikacji</string>
     <string name="logviewer_title">Przeglądarka logów</string>
-    <string name="creators_title">Twórcy</string>
+    <string name="contributors_title">Twórcy</string>
     <string name="license_title">Licencje</string>
     <string name="message_title">Wiadomości</string>
     <string name="send_message_title">Nowa wiadomość</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -15,7 +15,7 @@
     <string name="more_title">Ещё</string>
     <string name="about_title">О приложении</string>
     <string name="logviewer_title">Просмотр журнала</string>
-    <string name="creators_title">Творцы</string>
+    <string name="contributors_title">Творцы</string>
     <string name="license_title">Лицензии</string>
     <string name="message_title">Сообщения</string>
     <string name="send_message_title">Новое сообщение</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -14,8 +14,8 @@
     <string name="settings_title">Налаштування</string>
     <string name="more_title">Ще</string>
     <string name="about_title">Про додаток</string>
-    <string name="logviewer_title">Log viewer</string>
-    <string name="creators_title">Creators</string>
+    <string name="logviewer_title">Переглядач журналів</string>
+    <string name="contributors_title">Творці</string>
     <string name="license_title">Ліцензії</string>
     <string name="message_title">Повідомлення</string>
     <string name="send_message_title">Нове повідомлення</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
     <string name="more_title">More</string>
     <string name="about_title">About</string>
     <string name="logviewer_title">Log viewer</string>
-    <string name="creators_title">Creators</string>
+    <string name="creators_title">Contributors</string>
     <string name="license_title">Licenses</string>
     <string name="message_title">Messages</string>
     <string name="send_message_title">New message</string>
@@ -272,7 +272,7 @@
 
     <!--About-->
     <string name="about_version">App version</string>
-    <string name="about_creator">Creators</string>
+    <string name="about_creator">Contributors</string>
     <string name="about_creator_summary">List of Wulkanowy developers</string>
     <string name="about_feedback">Report a bug</string>
     <string name="about_feedback_summary">Send a bug report via e-mail</string>
@@ -295,6 +295,7 @@
     <!--Creators-->
     <string name="creator_avatar_description">Avatar</string>
     <string name="creator_see_more">See more on GitHub</string>
+
 
     <!--Log viewer-->
     <string name="logviewer_share">Share logs</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
     <string name="more_title">More</string>
     <string name="about_title">About</string>
     <string name="logviewer_title">Log viewer</string>
-    <string name="creators_title">Contributors</string>
+    <string name="contributors_title">Contributors</string>
     <string name="license_title">Licenses</string>
     <string name="message_title">Messages</string>
     <string name="send_message_title">New message</string>


### PR DESCRIPTION
In the case of multiple contributors, it is better to use the "contributor" term than the "creator" one, as this allows you to list the people who contributed to the project, not just those who created it from the beginning.