### PR TITLE
Fix displaying the feature disabled message in completed lessons

### DIFF
--- a/app/src/main/java/io/github/wulkanowy/ui/modules/timetable/completed/CompletedLessonsPresenter.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/timetable/completed/CompletedLessonsPresenter.kt
@@ -43,6 +43,7 @@ class CompletedLessonsPresenter @Inject constructor(
         completedLessonsErrorHandler.showErrorMessage = ::showErrorViewOnError
         completedLessonsErrorHandler.onFeatureDisabled = {
             this.view?.showFeatureDisabled()
+            this.view?.showEmpty(true);
             Timber.i("Completed lessons feature disabled by school")
         }
         loadData(ofEpochDay(date ?: baseDate.toEpochDay()))


### PR DESCRIPTION
Previously, the `completedLessonsErrorHandler` would call `showFeatureDisabled` without a subsequent call to `showEmpty` resulting in a hidden message. This PR fixes that.