### PR TITLE
Remove HiltBroadcastReceiver

### DIFF
--- a/app/src/main/java/io/github/wulkanowy/services/HiltBroadcastReceiver.kt
+++ b/app/src/main/java/io/github/wulkanowy/services/HiltBroadcastReceiver.kt
@@ -1,9 +1,0 @@
-package io.github.wulkanowy.services
-
-import android.content.BroadcastReceiver
-import android.content.Context
-import android.content.Intent
-
-abstract class HiltBroadcastReceiver : BroadcastReceiver() {
-    override fun onReceive(context: Context, intent: Intent) {}
-}

--- a/app/src/main/java/io/github/wulkanowy/services/alarm/TimetableNotificationReceiver.kt
+++ b/app/src/main/java/io/github/wulkanowy/services/alarm/TimetableNotificationReceiver.kt
@@ -1,6 +1,7 @@
 package io.github.wulkanowy.services.alarm
 
 import android.app.PendingIntent
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.os.Build
@@ -12,7 +13,6 @@ import io.github.wulkanowy.R
 import io.github.wulkanowy.data.Status
 import io.github.wulkanowy.data.repositories.PreferencesRepository
 import io.github.wulkanowy.data.repositories.StudentRepository
-import io.github.wulkanowy.services.HiltBroadcastReceiver
 import io.github.wulkanowy.services.sync.channels.UpcomingLessonsChannel.Companion.CHANNEL_ID
 import io.github.wulkanowy.ui.modules.Destination
 import io.github.wulkanowy.ui.modules.splash.SplashActivity
@@ -28,7 +28,7 @@ import timber.log.Timber
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class TimetableNotificationReceiver : HiltBroadcastReceiver() {
+class TimetableNotificationReceiver : BroadcastReceiver() {
 
     @Inject
     lateinit var studentRepository: StudentRepository
@@ -58,7 +58,6 @@ class TimetableNotificationReceiver : HiltBroadcastReceiver() {
 
     @OptIn(DelicateCoroutinesApi::class)
     override fun onReceive(context: Context, intent: Intent) {
-        super.onReceive(context, intent)
         Timber.d("Receiving intent... ${intent.toUri(0)}")
 
         flowWithResource {

--- a/app/src/main/java/io/github/wulkanowy/ui/modules/timetablewidget/TimetableWidgetProvider.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/timetablewidget/TimetableWidgetProvider.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetManager.*
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK
@@ -18,7 +19,6 @@ import io.github.wulkanowy.data.db.SharedPrefProvider
 import io.github.wulkanowy.data.db.entities.Student
 import io.github.wulkanowy.data.exceptions.NoCurrentStudentException
 import io.github.wulkanowy.data.repositories.StudentRepository
-import io.github.wulkanowy.services.HiltBroadcastReceiver
 import io.github.wulkanowy.services.widgets.TimetableWidgetService
 import io.github.wulkanowy.ui.modules.Destination
 import io.github.wulkanowy.ui.modules.splash.SplashActivity
@@ -33,7 +33,7 @@ import java.time.ZoneOffset
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class TimetableWidgetProvider : HiltBroadcastReceiver() {
+class TimetableWidgetProvider : BroadcastReceiver() {
 
     @Inject
     lateinit var appWidgetManager: AppWidgetManager
@@ -78,7 +78,6 @@ class TimetableWidgetProvider : HiltBroadcastReceiver() {
 
     @OptIn(DelicateCoroutinesApi::class)
     override fun onReceive(context: Context, intent: Intent) {
-        super.onReceive(context, intent)
         GlobalScope.launch {
             when (intent.action) {
                 ACTION_APPWIDGET_UPDATE -> onUpdate(context, intent)


### PR DESCRIPTION
It was created to work around an issue in Hilt, which was fixed in 2.29.1 (https://github.com/google/dagger/releases/tag/dagger-2.29.1) a year ago.

Related #909