### PR TITLE
Update row in mailboxes table on primary key conflict

### DIFF
--- a/app/src/main/java/io/github/wulkanowy/data/db/dao/BaseDao.kt
+++ b/app/src/main/java/io/github/wulkanowy/data/db/dao/BaseDao.kt
@@ -2,11 +2,12 @@ package io.github.wulkanowy.data.db.dao
 
 import androidx.room.Delete
 import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Update
 
 interface BaseDao<T> {
 
-    @Insert
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(items: List<T>): List<Long>
 
     @Update


### PR DESCRIPTION
Zmiana naprawia ten problem:

```
android.database.sqlite.SQLiteConstraintException: UNIQUE constraint failed: Mailboxes.globalKey (code 1555 SQLITE_CONSTRAINT_PRIMARYKEY[1555])
  at android.database.sqlite.SQLiteConnection.nativeExecuteForLastInsertedRowId(Native Method)
  at android.database.sqlite.SQLiteConnection.executeForLastInsertedRowId(SQLiteConnection.java:1127)
  at android.database.sqlite.SQLiteSession.executeForLastInsertedRowId(SQLiteSession.java:790)
  at android.database.sqlite.SQLiteStatement.executeInsert(SQLiteStatement.java:88)
  at androidx.sqlite.db.framework.FrameworkSQLiteStatement.executeInsert(FrameworkSQLiteStatement.java:51)
  at androidx.room.EntityInsertionAdapter.insertAndReturnIdsList(EntityInsertionAdapter.java:243)
  at io.github.wulkanowy.data.db.dao.MailboxDao_Impl$4.call(MailboxDao_Impl.java:156)
  at io.github.wulkanowy.data.db.dao.MailboxDao_Impl$4.call(MailboxDao_Impl.java:151)
  at androidx.room.CoroutinesRoom$Companion$execute$2.invokeSuspend(CoroutinesRoom.kt:65)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
  at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
  at androidx.room.TransactionExecutor$1.run(TransactionExecutor.java:47)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
  at java.lang.Thread.run(Thread.java:919)
```

Wynika to prawdopodobnie z [tej zmiany](https://github.com/wulkanowy/sdk/commit/3f777674347075787ed459f087e452cfaa128d80#diff-6bd06196ef3dd129e77b38842b2855a816ab27563dccf9c3c5e78e31fe397fb6R141) w SDK (podyktowanymi zastąpieniem modułu wiadomości Wiadomościami Plus, gdzie userLoginId nie występuje), przez którą w sytuacji gdy user wyloguje się i zaloguje ponownie, to jego userLoginId jest inne niż to zapisane wcześniej przy skrzynce pocztowej