### PR TITLE
Change message draft key in shared preferences

### DIFF
--- a/app/src/main/java/io/github/wulkanowy/data/repositories/MessageRepository.kt
+++ b/app/src/main/java/io/github/wulkanowy/data/repositories/MessageRepository.kt
@@ -167,10 +167,10 @@ class MessageRepository @Inject constructor(
     }
 
     var draftMessage: MessageDraft?
-        get() = sharedPrefProvider.getString(context.getString(R.string.pref_key_message_send_draft))
+        get() = sharedPrefProvider.getString(context.getString(R.string.pref_key_message_draft))
             ?.let { json.decodeFromString(it) }
         set(value) = sharedPrefProvider.putString(
-            context.getString(R.string.pref_key_message_send_draft),
+            context.getString(R.string.pref_key_message_draft),
             value?.let { json.encodeToString(it) }
         )
 }

--- a/app/src/main/res/values/preferences_keys.xml
+++ b/app/src/main/res/values/preferences_keys.xml
@@ -31,8 +31,7 @@
     <string name="pref_key_homework_fullscreen">homework_fullscreen</string>
     <string name="pref_key_subjects_without_grades">subjects_without_grades</string>
     <string name="pref_key_optional_arithmetic_average">optional_arithmetic_average</string>
-    <string name="pref_key_message_send_is_draft">message_send_is_draft</string>
-    <string name="pref_key_message_send_draft">message_send_recipients</string>
+    <string name="pref_key_message_draft">message_draft</string>
     <string name="pref_key_last_sync_date">last_sync_date</string>
     <string name="pref_key_notifications_piggyback">notifications_piggyback</string>
     <string name="pref_key_notifications_piggyback_cancel_original">notifications_piggyback_cancel_original</string>


### PR DESCRIPTION
Ze względu na zmiany w modelach, dane zapisane pod tym kluczem w starszych wersjach apki są niekompatybilne z modelami z wersji 1.7.x, co powoduje crash apki przy próbie napisania nowej wiadomości. 

Ze względu na to, że funkcjonalność draftów w naszej apce powinna zostać zamieniona na tę z nowych Wiadomości Plus, to poprawka to proste zmienienie klucza - nie widzę sensu w robieniu bardziej skomplikowanej migracji