### PR TITLE
Fix SSL certificate out-of-date detection

### DIFF
--- a/app/src/main/java/io/github/wulkanowy/utils/ExceptionExtension.kt
+++ b/app/src/main/java/io/github/wulkanowy/utils/ExceptionExtension.kt
@@ -15,16 +15,17 @@ import java.net.ConnectException
 import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
+import java.security.cert.CertPathValidatorException
 import java.security.cert.CertificateExpiredException
 import java.security.cert.CertificateNotYetValidException
 import javax.net.ssl.SSLHandshakeException
 
 fun Resources.getErrorString(error: Throwable): String = when (error) {
     is UnknownHostException -> R.string.error_no_internet
+    is ConnectException,
     is SocketException,
     is SocketTimeoutException,
     is InterruptedIOException,
-    is ConnectException,
     is StreamResetException -> R.string.error_timeout
     is NotLoggedInException -> R.string.error_login_failed
     is PasswordChangeRequiredException -> R.string.error_password_change_required
@@ -42,10 +43,10 @@ fun Resources.getErrorString(error: Throwable): String = when (error) {
 
 fun Throwable.isShouldBeReported(): Boolean = when (this) {
     is UnknownHostException,
+    is ConnectException,
     is SocketException,
     is SocketTimeoutException,
     is InterruptedIOException,
-    is ConnectException,
     is StreamResetException,
     is ServiceUnavailableException,
     is FeatureDisabledException,
@@ -70,5 +71,6 @@ private fun Throwable?.isCausedByCertificateNotValidNow(): Boolean {
 private fun Throwable?.isCertificateNotValidNow(): Boolean {
     val isNotYetValid = this is CertificateNotYetValidException
     val isExpired = this is CertificateExpiredException
-    return isNotYetValid || isExpired
+    val isInvalidPath = this is CertPathValidatorException
+    return isNotYetValid || isExpired || isInvalidPath
 }


### PR DESCRIPTION
Related #1742
```
E/Wulkanowy: An exception occurred while the Wulkanowy was running
E/Wulkanowy: javax.net.ssl.SSLHandshakeException: Chain validation failed
E/Wulkanowy:     at com.android.org.conscrypt.SSLUtils.toSSLHandshakeException(SSLUtils.java:363)
E/Wulkanowy:     at com.android.org.conscrypt.ConscryptEngine.convertException(ConscryptEngine.java:1134)
E/Wulkanowy:     at com.android.org.conscrypt.ConscryptEngine.readPlaintextData(ConscryptEngine.java:1089)
E/Wulkanowy:     at com.android.org.conscrypt.ConscryptEngine.unwrap(ConscryptEngine.java:876)
E/Wulkanowy:     at com.android.org.conscrypt.ConscryptEngine.unwrap(ConscryptEngine.java:747)
E/Wulkanowy:     at com.android.org.conscrypt.ConscryptEngine.unwrap(ConscryptEngine.java:712)
E/Wulkanowy:     at com.android.org.conscrypt.ConscryptEngineSocket$SSLInputStream.processDataFromSocket(ConscryptEngineSocket.java:858)
E/Wulkanowy:     at com.android.org.conscrypt.ConscryptEngineSocket$SSLInputStream.-$$Nest$mprocessDataFromSocket(Unknown Source:0)
E/Wulkanowy:     at com.android.org.conscrypt.ConscryptEngineSocket.doHandshake(ConscryptEngineSocket.java:241)
E/Wulkanowy:     at com.android.org.conscrypt.ConscryptEngineSocket.startHandshake(ConscryptEngineSocket.java:220)
E/Wulkanowy:     at okhttp3.internal.connection.RealConnection.connectTls(RealConnection.kt:379)
E/Wulkanowy:     at okhttp3.internal.connection.RealConnection.establishProtocol(RealConnection.kt:337)
E/Wulkanowy:     at okhttp3.internal.connection.RealConnection.connect(RealConnection.kt:209)
E/Wulkanowy:     at okhttp3.internal.connection.ExchangeFinder.findConnection(ExchangeFinder.kt:226)
E/Wulkanowy:     at okhttp3.internal.connection.ExchangeFinder.findHealthyConnection(ExchangeFinder.kt:106)
E/Wulkanowy:     at okhttp3.internal.connection.ExchangeFinder.find(ExchangeFinder.kt:74)
E/Wulkanowy:     at okhttp3.internal.connection.RealCall.initExchange$okhttp(RealCall.kt:255)
E/Wulkanowy:     at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.kt:32)
E/Wulkanowy:     at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
E/Wulkanowy:     at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.kt:95)
E/Wulkanowy:     at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
E/Wulkanowy:     at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:83)
E/Wulkanowy:     at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
E/Wulkanowy:     at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:76)
E/Wulkanowy:     at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
E/Wulkanowy:     at io.github.wulkanowy.sdk.scrapper.interceptor.StudentCookieInterceptor.intercept(StudentCookieInterceptor.kt:33)
E/Wulkanowy:     at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
E/Wulkanowy:     at io.github.wulkanowy.sdk.scrapper.interceptor.HttpErrorInterceptor.intercept(HttpErrorInterceptor.kt:13)
E/Wulkanowy:     at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
E/Wulkanowy:     at io.github.wulkanowy.sdk.scrapper.interceptor.UserAgentInterceptor.intercept(UserAgentInterceptor.kt:18)
E/Wulkanowy:     at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
E/Wulkanowy:     at io.github.wulkanowy.sdk.scrapper.interceptor.AutoLoginInterceptor.intercept(AutoLoginInterceptor.kt:59)
E/Wulkanowy:     at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
E/Wulkanowy:     at io.github.wulkanowy.sdk.scrapper.interceptor.ErrorInterceptor.intercept(ErrorInterceptor.kt:25)
E/Wulkanowy:     at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
E/Wulkanowy:     at okhttp3.logging.HttpLoggingInterceptor.intercept(HttpLoggingInterceptor.kt:221)
E/Wulkanowy:     at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
E/Wulkanowy:     at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:201)
E/Wulkanowy:     at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:517)
E/Wulkanowy:     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
E/Wulkanowy:     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
E/Wulkanowy:     at java.lang.Thread.run(Thread.java:1012)
E/Wulkanowy: Caused by: java.security.cert.CertificateException: Chain validation failed
E/Wulkanowy:     at com.android.org.conscrypt.TrustManagerImpl.verifyChain(TrustManagerImpl.java:717)
E/Wulkanowy:     at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:547)
E/Wulkanowy:     at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:568)
E/Wulkanowy:     at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:613)
E/Wulkanowy:     at com.android.org.conscrypt.TrustManagerImpl.checkTrusted(TrustManagerImpl.java:503)
E/Wulkanowy:     at com.android.org.conscrypt.TrustManagerImpl.checkTrusted(TrustManagerImpl.java:423)
E/Wulkanowy:     at com.android.org.conscrypt.TrustManagerImpl.getTrustedChainForServer(TrustManagerImpl.java:351)
E/Wulkanowy:     at android.security.net.config.NetworkSecurityTrustManager.checkServerTrusted(NetworkSecurityTrustManager.java:94)
E/Wulkanowy:     at android.security.net.config.RootTrustManager.checkServerTrusted(RootTrustManager.java:90)
E/Wulkanowy:     at com.android.org.conscrypt.ConscryptEngineSocket$2.checkServerTrusted(ConscryptEngineSocket.java:163)
E/Wulkanowy:     at com.android.org.conscrypt.Platform.checkServerTrusted(Platform.java:255)
E/Wulkanowy:     at com.android.org.conscrypt.ConscryptEngine.verifyCertificateChain(ConscryptEngine.java:1638)
E/Wulkanowy:     at com.android.org.conscrypt.NativeCrypto.ENGINE_SSL_read_direct(Native Method)
E/Wulkanowy:     at com.android.org.conscrypt.NativeSsl.readDirectByteBuffer(NativeSsl.java:569)
E/Wulkanowy:     at com.android.org.conscrypt.ConscryptEngine.readPlaintextDataDirect(ConscryptEngine.java:1095)
E/Wulkanowy:     at com.android.org.conscrypt.ConscryptEngine.readPlaintextData(ConscryptEngine.java:1079)
E/Wulkanowy: 	... 39 more
E/Wulkanowy: Caused by: java.security.cert.CertPathValidatorException: Response is unreliable: its validity interval is out-of-date
E/Wulkanowy:     at sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:135)
E/Wulkanowy:     at sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:222)
E/Wulkanowy:     at sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:140)
E/Wulkanowy:     at sun.security.provider.certpath.PKIXCertPathValidator.engineValidate(PKIXCertPathValidator.java:79)
E/Wulkanowy:     at java.security.cert.CertPathValidator.validate(CertPathValidator.java:309)
E/Wulkanowy:     at com.android.org.conscrypt.TrustManagerImpl.verifyChain(TrustManagerImpl.java:713)
E/Wulkanowy: 	... 54 more
E/Wulkanowy: Caused by: java.security.cert.CertPathValidatorException: Response is unreliable: its validity interval is out-of-date
E/Wulkanowy:     at sun.security.provider.certpath.OCSPResponse.verify(OCSPResponse.java:619)
E/Wulkanowy:     at sun.security.provider.certpath.RevocationChecker.checkOCSP(RevocationChecker.java:709)
E/Wulkanowy:     at sun.security.provider.certpath.RevocationChecker.check(RevocationChecker.java:363)
E/Wulkanowy:     at sun.security.provider.certpath.RevocationChecker.check(RevocationChecker.java:337)
E/Wulkanowy:     at sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:125)
E/Wulkanowy: 	... 59 more
E/Wulkanowy: 	Suppressed: java.security.cert.CertPathValidatorException: Could not determine revocation status
E/Wulkanowy:     at sun.security.provider.certpath.RevocationChecker.buildToNewKey(RevocationChecker.java:1092)
E/Wulkanowy:     at sun.security.provider.certpath.RevocationChecker.verifyWithSeparateSigningKey(RevocationChecker.java:910)
E/Wulkanowy:     at sun.security.provider.certpath.RevocationChecker.checkCRLs(RevocationChecker.java:577)
E/Wulkanowy:     at sun.security.provider.certpath.RevocationChecker.checkCRLs(RevocationChecker.java:465)
E/Wulkanowy:     at sun.security.provider.certpath.RevocationChecker.check(RevocationChecker.java:394)
E/Wulkanowy: 		... 61 more
```