### PR TITLE
Try to switch to next school year before it starts

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -191,7 +191,7 @@ ext {
 }
 
 dependencies {
-    implementation 'io.github.wulkanowy:sdk:2.0.8'
+    implementation 'io.github.wulkanowy:sdk:2.0.9-SNAPSHOT'
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
 

--- a/app/src/main/java/io/github/wulkanowy/data/repositories/SemesterRepository.kt
+++ b/app/src/main/java/io/github/wulkanowy/data/repositories/SemesterRepository.kt
@@ -41,7 +41,7 @@ class SemesterRepository @Inject constructor(
 
         val isRefreshOnModeChangeRequired = when {
             Sdk.Mode.valueOf(student.loginMode) != Sdk.Mode.HEBE -> {
-                semesters.firstOrNull { it.isCurrent }?.let {
+                semesters.firstOrNull { it.isCurrent() }?.let {
                     0 == it.diaryId && 0 == it.kindergartenDiaryId
                 } == true
             }
@@ -49,7 +49,7 @@ class SemesterRepository @Inject constructor(
         }
 
         val isRefreshOnNoCurrentAppropriate =
-            refreshOnNoCurrent && !semesters.any { semester -> semester.isCurrent }
+            refreshOnNoCurrent && !semesters.any { semester -> semester.isCurrent() }
 
         return forceRefresh || isNoSemesters || isRefreshOnModeChangeRequired || isRefreshOnNoCurrentAppropriate
     }

--- a/app/src/main/java/io/github/wulkanowy/utils/SemesterExtension.kt
+++ b/app/src/main/java/io/github/wulkanowy/utils/SemesterExtension.kt
@@ -1,16 +1,27 @@
 package io.github.wulkanowy.utils
 
 import io.github.wulkanowy.data.db.entities.Semester
+import java.time.LocalDate
 import java.time.LocalDate.now
+import java.time.Month
 
-inline val Semester.isCurrent: Boolean
-    get() = now() in start..end
+fun Semester.isCurrent(now: LocalDate = now()): Boolean {
+    val shiftedStart = if (start.month == Month.SEPTEMBER) {
+        start.minusDays(3)
+    } else start
+
+    val shiftedEnd = if (end.month == Month.AUGUST || end.month == Month.SEPTEMBER) {
+        end.minusDays(3)
+    } else end
+
+    return now in shiftedStart..shiftedEnd
+}
 
 fun List<Semester>.getCurrentOrLast(): Semester {
     if (isEmpty()) throw RuntimeException("Empty semester list")
 
     // when there is only one current semester
-    singleOrNull { it.isCurrent }?.let { return it }
+    singleOrNull { it.isCurrent() }?.let { return it }
 
     // when there is more than one current semester - find one with higher id
     singleOrNull { semester -> semester.semesterId == maxByOrNull { it.semesterId }?.semesterId }?.let { return it }

--- a/app/src/test/java/io/github/wulkanowy/utils/SemesterExtensionKtTest.kt
+++ b/app/src/test/java/io/github/wulkanowy/utils/SemesterExtensionKtTest.kt
@@ -8,6 +8,40 @@ import kotlin.test.assertEquals
 
 class SemesterExtensionKtTest {
 
+    @Test
+    fun `check is first semester is current`() {
+        val first = getSemesterEntity(
+            semesterName = 1,
+            start = LocalDate.of(2023, 9, 1),
+            end = LocalDate.of(2024, 1, 31),
+        )
+
+        // first boundary - school-year start
+        assertEquals(false, first.isCurrent(LocalDate.of(2023, 8, 28)))
+        assertEquals(true, first.isCurrent(LocalDate.of(2023, 8, 29)))
+
+        // second boundary
+        assertEquals(true, first.isCurrent(LocalDate.of(2024, 1, 31)))
+        assertEquals(false, first.isCurrent(LocalDate.of(2024, 2, 1)))
+    }
+
+    @Test
+    fun `check is second semester is current`() {
+        val second = getSemesterEntity(
+            semesterName = 2,
+            start = LocalDate.of(2024, 2, 1),
+            end = LocalDate.of(2024, 9, 1),
+        )
+
+        // first boundary
+        assertEquals(false, second.isCurrent(LocalDate.of(2024, 1, 31)))
+        assertEquals(true, second.isCurrent(LocalDate.of(2024, 2, 1)))
+
+        // second boundary - school-year end
+        assertEquals(true, second.isCurrent(LocalDate.of(2024, 8, 29)))
+        assertEquals(false, second.isCurrent(LocalDate.of(2024, 8, 30)))
+    }
+
     @Test(expected = IllegalArgumentException::class)
     fun `get current semester when current is doubled`() {
         val semesters = listOf(


### PR DESCRIPTION
Resolves #1490

Dzięki tej zmianie, mimo, że rok szkolny 2023/2024 zaczyna się oficjalnie 4 września, dziennik zwraca informację, że pierwszy semestr startuje 1 września (sprawdzane w dzienniku u kilku różnych uczniów), to dodatkowo jeszcze Wulkanowy będzie próbował wyświetlić ten nowy semestr jeszcze wcześniej, bo aż 3 dni przed 1 września, czyli 29 sierpnia.

Czemu akurat 3 dni? W niektórych szkołach egzaminy poprawkowe odbywają się jeszcze do okolic właśnie 29 sierpnia i dlatego ta data wydaje mi się być dobrym ograniczeniem