### PR TITLE
Fix average calculation when there is no real semesters available

### DIFF
--- a/app/src/main/java/io/github/wulkanowy/ui/modules/grade/GradeAverageProvider.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/grade/GradeAverageProvider.kt
@@ -58,7 +58,7 @@ class GradeAverageProvider @Inject constructor(
             when (params.gradeAverageMode) {
                 ONE_SEMESTER -> getGradeSubjects(
                     student = student,
-                    semester = semesters.single { it.semesterId == semesterId },
+                    semester = semesters.first { it.semesterId == semesterId },
                     forceRefresh = forceRefresh,
                     params = params,
                 )


### PR DESCRIPTION
workaround dla
```
java.lang.IllegalArgumentException: Collection contains more than one matching element.
at io.github.wulkanowy.ui.modules.grade.GradeAverageProvider$getGradesDetailsWithAverage$2$1.invokeSuspend(GradeAverageProvider.kt:622)
at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
at android.os.Handler.handleCallback(Handler.java:942)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loopOnce(Looper.java:211)
at android.os.Looper.loop(Looper.java:300)
at android.app.ActivityThread.main(ActivityThread.java:8289)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:559)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:954)
```

Taka sytuacja może się zdarzyć np. wtedy, gdy uczeń chodzi tak naprawdę do przedszkola, gdzie w zasadzie jest tylko jeden semestr:
```
Semester(studentId=123, diaryId=0, kindergartenDiaryId=14, diaryName=3P1, schoolYear=2021, semesterId=0, semesterName=1, start=2021-09-01, end=2022-08-31, classId=0, unitId=8)
Semester(studentId=123, diaryId=0, kindergartenDiaryId=15, diaryName=12P2, schoolYear=2021, semesterId=0, semesterName=1, start=2021-09-01, end=2022-08-31, classId=0, unitId=8)
```