### PR TITLE
Add colors to attendance and ! to unexcused lateness

### DIFF
--- a/app/src/main/java/io/github/wulkanowy/ui/modules/attendance/AttendanceAdapter.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/attendance/AttendanceAdapter.kt
@@ -44,17 +44,21 @@ class AttendanceAdapter @Inject constructor() :
 
             attendanceItemDescription.setTextColor(
                 root.context.getThemeAttrColor(
-                    if (item.absence && !item.excused) R.attr.colorAttendanceAbsence
-                    else if (item.absence) R.attr.colorAttendanceAbsenceExcused
-                    else if (item.lateness) R.attr.colorAttendanceLateness
-                    else android.R.attr.textColorSecondary
+                    when {
+                        item.absence && !item.excused -> R.attr.colorAttendanceAbsence
+                        item.absence -> R.attr.colorAttendanceAbsenceExcused
+                        item.lateness -> R.attr.colorAttendanceLateness
+                        else -> android.R.attr.textColorSecondary
+                    }
                 )
             )
 
-            if (item.exemption)
+            if (item.exemption) {
                 attendanceItemDescription.setTypeface(null, Typeface.BOLD)
-            else
+            }
+            else {
                 attendanceItemDescription.setTypeface(null, Typeface.NORMAL)
+            }
 
             attendanceItemAlert.isVisible =
                 item.let { (it.absence && !it.excused) || (it.lateness && !it.excused) }

--- a/app/src/main/java/io/github/wulkanowy/ui/modules/attendance/AttendanceAdapter.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/attendance/AttendanceAdapter.kt
@@ -1,5 +1,6 @@
 package io.github.wulkanowy.ui.modules.attendance
 
+import android.graphics.Typeface
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -10,6 +11,7 @@ import io.github.wulkanowy.data.db.entities.Attendance
 import io.github.wulkanowy.data.enums.SentExcuseStatus
 import io.github.wulkanowy.databinding.ItemAttendanceBinding
 import io.github.wulkanowy.utils.descriptionRes
+import io.github.wulkanowy.utils.getThemeAttrColor
 import io.github.wulkanowy.utils.isExcusableOrNotExcused
 import javax.inject.Inject
 
@@ -39,7 +41,23 @@ class AttendanceAdapter @Inject constructor() :
                 root.context.getString(R.string.all_no_data)
             }
             attendanceItemDescription.setText(item.descriptionRes)
-            attendanceItemAlert.isVisible = item.let { it.absence && !it.excused }
+
+            attendanceItemDescription.setTextColor(
+                root.context.getThemeAttrColor(
+                    if (item.absence && !item.excused) R.attr.colorAttendanceAbsence
+                    else if (item.absence) R.attr.colorAttendanceAbsenceExcused
+                    else if (item.lateness) R.attr.colorAttendanceLateness
+                    else android.R.attr.textColorSecondary
+                )
+            )
+
+            if (item.exemption)
+                attendanceItemDescription.setTypeface(null, Typeface.BOLD)
+            else
+                attendanceItemDescription.setTypeface(null, Typeface.NORMAL)
+
+            attendanceItemAlert.isVisible =
+                item.let { (it.absence && !it.excused) || (it.lateness && !it.excused) }
             attendanceItemNumber.visibility = View.GONE
             attendanceItemExcuseInfo.visibility = View.GONE
             attendanceItemExcuseCheckbox.visibility = View.GONE
@@ -54,10 +72,12 @@ class AttendanceAdapter @Inject constructor() :
                     attendanceItemExcuseInfo.visibility = View.VISIBLE
                     attendanceItemAlert.visibility = View.INVISIBLE
                 }
+
                 SentExcuseStatus.DENIED -> {
                     attendanceItemExcuseInfo.setImageResource(R.drawable.ic_excuse_denied)
                     attendanceItemExcuseInfo.visibility = View.VISIBLE
                 }
+
                 else -> {
                     if (item.isExcusableOrNotExcused && excuseActionMode) {
                         attendanceItemNumber.visibility = View.GONE

--- a/app/src/main/java/io/github/wulkanowy/ui/modules/attendance/AttendanceAdapter.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/attendance/AttendanceAdapter.kt
@@ -46,14 +46,13 @@ class AttendanceAdapter @Inject constructor() :
                 root.context.getThemeAttrColor(
                     when {
                         item.absence && !item.excused -> R.attr.colorAttendanceAbsence
-                        item.absence -> R.attr.colorAttendanceAbsenceExcused
-                        item.lateness -> R.attr.colorAttendanceLateness
+                        item.lateness && !item.excused -> R.attr.colorAttendanceLateness
                         else -> android.R.attr.textColorSecondary
                     }
                 )
             )
 
-            if (item.exemption) {
+            if (item.exemption || item.excused) {
                 attendanceItemDescription.setTypeface(null, Typeface.BOLD)
             } else {
                 attendanceItemDescription.setTypeface(null, Typeface.NORMAL)
@@ -61,6 +60,14 @@ class AttendanceAdapter @Inject constructor() :
 
             attendanceItemAlert.isVisible =
                 item.let { (it.absence && !it.excused) || (it.lateness && !it.excused) }
+
+            attendanceItemAlert.setColorFilter(root.context.getThemeAttrColor(
+                when{
+                    item.absence && !item.excused -> R.attr.colorAttendanceAbsence
+                    item.lateness && !item.excused -> R.attr.colorAttendanceLateness
+                    else -> android.R.attr.colorPrimary
+                }
+            ))
             attendanceItemNumber.visibility = View.GONE
             attendanceItemExcuseInfo.visibility = View.GONE
             attendanceItemExcuseCheckbox.visibility = View.GONE

--- a/app/src/main/java/io/github/wulkanowy/ui/modules/attendance/AttendanceAdapter.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/attendance/AttendanceAdapter.kt
@@ -55,8 +55,7 @@ class AttendanceAdapter @Inject constructor() :
 
             if (item.exemption) {
                 attendanceItemDescription.setTypeface(null, Typeface.BOLD)
-            }
-            else {
+            } else {
                 attendanceItemDescription.setTypeface(null, Typeface.NORMAL)
             }
 

--- a/app/src/main/java/io/github/wulkanowy/ui/modules/attendance/AttendanceDialog.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/attendance/AttendanceDialog.kt
@@ -48,10 +48,12 @@ class AttendanceDialog : BaseDialogFragment<DialogAttendanceBinding>() {
             attendanceDialogDescriptionValue.setText(attendance.descriptionRes)
             attendanceDialogDescriptionValue.setTextColor(
                 root.context.getThemeAttrColor(
-                    if (attendance.absence && !attendance.excused) R.attr.colorAttendanceAbsence
-                    else if (attendance.absence) R.attr.colorAttendanceAbsenceExcused
-                    else if (attendance.lateness) R.attr.colorAttendanceLateness
-                    else android.R.attr.textColorSecondary
+                    when {
+                        attendance.absence && !attendance.excused -> R.attr.colorAttendanceAbsence
+                        attendance.absence -> R.attr.colorAttendanceAbsenceExcused
+                        attendance.lateness -> R.attr.colorAttendanceLateness
+                        else -> android.R.attr.textColorSecondary
+                    }
                 )
             )
 

--- a/app/src/main/java/io/github/wulkanowy/ui/modules/attendance/AttendanceDialog.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/attendance/AttendanceDialog.kt
@@ -6,10 +6,12 @@ import android.view.View
 import androidx.core.os.bundleOf
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
+import io.github.wulkanowy.R
 import io.github.wulkanowy.data.db.entities.Attendance
 import io.github.wulkanowy.databinding.DialogAttendanceBinding
 import io.github.wulkanowy.ui.base.BaseDialogFragment
 import io.github.wulkanowy.utils.descriptionRes
+import io.github.wulkanowy.utils.getThemeAttrColor
 import io.github.wulkanowy.utils.serializable
 import io.github.wulkanowy.utils.toFormattedString
 
@@ -44,6 +46,15 @@ class AttendanceDialog : BaseDialogFragment<DialogAttendanceBinding>() {
         with(binding) {
             attendanceDialogSubjectValue.text = attendance.subject
             attendanceDialogDescriptionValue.setText(attendance.descriptionRes)
+            attendanceDialogDescriptionValue.setTextColor(
+                root.context.getThemeAttrColor(
+                    if (attendance.absence && !attendance.excused) R.attr.colorAttendanceAbsence
+                    else if (attendance.absence) R.attr.colorAttendanceAbsenceExcused
+                    else if (attendance.lateness) R.attr.colorAttendanceLateness
+                    else android.R.attr.textColorSecondary
+                )
+            )
+
             attendanceDialogDateValue.text = attendance.date.toFormattedString()
             attendanceDialogNumberValue.text = attendance.number.toString()
             attendanceDialogClose.setOnClickListener { dismiss() }

--- a/app/src/main/java/io/github/wulkanowy/ui/modules/attendance/AttendanceDialog.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/attendance/AttendanceDialog.kt
@@ -50,8 +50,7 @@ class AttendanceDialog : BaseDialogFragment<DialogAttendanceBinding>() {
                 root.context.getThemeAttrColor(
                     when {
                         attendance.absence && !attendance.excused -> R.attr.colorAttendanceAbsence
-                        attendance.absence -> R.attr.colorAttendanceAbsenceExcused
-                        attendance.lateness -> R.attr.colorAttendanceLateness
+                        attendance.lateness && !attendance.excused -> R.attr.colorAttendanceLateness
                         else -> android.R.attr.textColorSecondary
                     }
                 )

--- a/app/src/main/res/values-night-v31/styles.xml
+++ b/app/src/main/res/values-night-v31/styles.xml
@@ -33,7 +33,6 @@
         <item name="colorTimetableCanceled">@color/timetable_canceled_dark</item>
         <item name="colorTimetableChange">@color/timetable_change_dark</item>
         <item name="colorAttendanceAbsence">@color/attendance_absence_dark</item>
-        <item name="colorAttendanceAbsenceExcused">@color/attendance_absence_excused_dark</item>
         <item name="colorAttendanceLateness">@color/attendance_lateness_dark</item>
 
         <item name="colorError">@color/colorErrorLight</item>

--- a/app/src/main/res/values-night-v31/styles.xml
+++ b/app/src/main/res/values-night-v31/styles.xml
@@ -32,6 +32,10 @@
         <item name="colorPrimaryInverse">@color/material_dynamic_primary40</item>
         <item name="colorTimetableCanceled">@color/timetable_canceled_dark</item>
         <item name="colorTimetableChange">@color/timetable_change_dark</item>
+        <item name="colorAttendanceAbsence">@color/attendance_absence_dark</item>
+        <item name="colorAttendanceAbsenceExcused">@color/attendance_absence_excused_dark</item>
+        <item name="colorAttendanceLateness">@color/attendance_lateness_dark</item>
+
         <item name="colorError">@color/colorErrorLight</item>
         <item name="colorDivider">@color/colorDividerInverse</item>
         <item name="colorSwipeRefresh">@color/material_dynamic_secondary20</item>

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -22,7 +22,6 @@
         <item name="colorTimetableCanceled">@color/timetable_canceled_dark</item>
         <item name="colorTimetableChange">@color/timetable_change_dark</item>
         <item name="colorAttendanceAbsence">@color/attendance_absence_dark</item>
-        <item name="colorAttendanceAbsenceExcused">@color/attendance_absence_excused_dark</item>
         <item name="colorAttendanceLateness">@color/attendance_lateness_dark</item>
         <item name="colorError">@color/colorErrorLight</item>
         <item name="colorDivider">@color/colorDividerInverse</item>

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -21,6 +21,9 @@
         <item name="colorSurface">@color/colorSurfaceDark</item>
         <item name="colorTimetableCanceled">@color/timetable_canceled_dark</item>
         <item name="colorTimetableChange">@color/timetable_change_dark</item>
+        <item name="colorAttendanceAbsence">@color/attendance_absence_dark</item>
+        <item name="colorAttendanceAbsenceExcused">@color/attendance_absence_excused_dark</item>
+        <item name="colorAttendanceLateness">@color/attendance_lateness_dark</item>
         <item name="colorError">@color/colorErrorLight</item>
         <item name="colorDivider">@color/colorDividerInverse</item>
         <item name="colorSwipeRefresh">@color/colorSwipeRefreshDark</item>

--- a/app/src/main/res/values-v31/styles.xml
+++ b/app/src/main/res/values-v31/styles.xml
@@ -35,7 +35,6 @@
         <item name="colorTimetableCanceled">@color/timetable_canceled_light</item>
         <item name="colorTimetableChange">@color/timetable_change_light</item>
         <item name="colorAttendanceAbsence">@color/attendance_absence_light</item>
-        <item name="colorAttendanceAbsenceExcused">@color/attendance_absence_excused_light</item>
         <item name="colorAttendanceLateness">@color/attendance_lateness_light</item>
 
         <item name="colorError">@color/colorError</item>

--- a/app/src/main/res/values-v31/styles.xml
+++ b/app/src/main/res/values-v31/styles.xml
@@ -34,6 +34,10 @@
         <item name="colorPrimaryInverse">@color/material_dynamic_primary80</item>
         <item name="colorTimetableCanceled">@color/timetable_canceled_light</item>
         <item name="colorTimetableChange">@color/timetable_change_light</item>
+        <item name="colorAttendanceAbsence">@color/attendance_absence_light</item>
+        <item name="colorAttendanceAbsenceExcused">@color/attendance_absence_excused_light</item>
+        <item name="colorAttendanceLateness">@color/attendance_lateness_light</item>
+
         <item name="colorError">@color/colorError</item>
         <item name="colorDivider">@color/colorDivider</item>
         <item name="colorSwipeRefresh">@color/material_dynamic_secondary90</item>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -8,6 +8,5 @@
     <attr name="colorMessageHigh" format="color" />
     <attr name="colorOnMessageHigh" format="color" />
     <attr name="colorAttendanceAbsence" format="color" />
-    <attr name="colorAttendanceAbsenceExcused" format="color" />
     <attr name="colorAttendanceLateness" format="color" />
 </resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -7,4 +7,7 @@
     <attr name="colorMessageMedium" format="color" />
     <attr name="colorMessageHigh" format="color" />
     <attr name="colorOnMessageHigh" format="color" />
+    <attr name="colorAttendanceAbsence" format="color" />
+    <attr name="colorAttendanceAbsenceExcused" format="color" />
+    <attr name="colorAttendanceLateness" format="color" />
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -49,6 +49,15 @@
     <color name="timetable_change_light">#ff8f00</color>
     <color name="timetable_change_dark">#ffd54f</color>
 
+    <color name="attendance_absence_light">#d32f2f</color>
+    <color name="attendance_absence_dark">#e57373</color>
+
+    <color name="attendance_absence_excused_light">#3c763d</color>
+    <color name="attendance_absence_excused_dark">#2ed128</color>
+
+    <color name="attendance_lateness_light">#ff8f00</color>
+    <color name="attendance_lateness_dark">#ffd54f</color>
+
     <color name="colorDivider">#1f000000</color>
     <color name="colorDividerInverse">#1fffffff</color>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -52,10 +52,7 @@
     <color name="attendance_absence_light">#d32f2f</color>
     <color name="attendance_absence_dark">#e57373</color>
 
-    <color name="attendance_absence_excused_light">#3c763d</color>
-    <color name="attendance_absence_excused_dark">#2ed128</color>
-
-    <color name="attendance_lateness_light">#ff8f00</color>
+    <color name="attendance_lateness_light">#cd2a01</color>
     <color name="attendance_lateness_dark">#f05d0e</color>
 
     <color name="colorDivider">#1f000000</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -56,7 +56,7 @@
     <color name="attendance_absence_excused_dark">#2ed128</color>
 
     <color name="attendance_lateness_light">#ff8f00</color>
-    <color name="attendance_lateness_dark">#ffd54f</color>
+    <color name="attendance_lateness_dark">#f05d0e</color>
 
     <color name="colorDivider">#1f000000</color>
     <color name="colorDividerInverse">#1fffffff</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -20,7 +20,6 @@
         <item name="colorTimetableCanceled">@color/timetable_canceled_light</item>
         <item name="colorTimetableChange">@color/timetable_change_light</item>
         <item name="colorAttendanceAbsence">@color/attendance_absence_light</item>
-        <item name="colorAttendanceAbsenceExcused">@color/attendance_absence_excused_light</item>
         <item name="colorAttendanceLateness">@color/attendance_lateness_light</item>
         <item name="colorError">@color/colorError</item>
         <item name="colorDivider">@color/colorDivider</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -19,6 +19,9 @@
         <item name="colorSurface">@color/colorSurface</item>
         <item name="colorTimetableCanceled">@color/timetable_canceled_light</item>
         <item name="colorTimetableChange">@color/timetable_change_light</item>
+        <item name="colorAttendanceAbsence">@color/attendance_absence_light</item>
+        <item name="colorAttendanceAbsenceExcused">@color/attendance_absence_excused_light</item>
+        <item name="colorAttendanceLateness">@color/attendance_lateness_light</item>
         <item name="colorError">@color/colorError</item>
         <item name="colorDivider">@color/colorDivider</item>
         <item name="colorSwipeRefresh">@color/colorSwipeRefresh</item>


### PR DESCRIPTION
Kolory we frekwencji:
- czerwony dla nieobecności nieusprawiedliwionej
- pomarańczowo-czerwony dla spóźnienia nieusprawiedliwionego

Spóźnienia usprawiedliwione, nieobecności usprawiedliwione, zwolnienia są pogrubiane
Resolves #2405