### PR TITLE
Fix displaying lessons for tomorrow if there is no more lessons for today

### DIFF
--- a/app/src/main/java/io/github/wulkanowy/domain/timetable/IsStudentHasLessonsOnWeekendUseCase.kt
+++ b/app/src/main/java/io/github/wulkanowy/domain/timetable/IsStudentHasLessonsOnWeekendUseCase.kt
@@ -1,0 +1,33 @@
+package io.github.wulkanowy.domain.timetable
+
+import io.github.wulkanowy.data.dataOrNull
+import io.github.wulkanowy.data.db.entities.Semester
+import io.github.wulkanowy.data.db.entities.Student
+import io.github.wulkanowy.data.repositories.TimetableRepository
+import io.github.wulkanowy.data.toFirstResult
+import io.github.wulkanowy.utils.monday
+import io.github.wulkanowy.utils.sunday
+import java.time.LocalDate
+import javax.inject.Inject
+
+class IsStudentHasLessonsOnWeekendUseCase @Inject constructor(
+    private val timetableRepository: TimetableRepository,
+    private val isWeekendHasLessonsUseCase: IsWeekendHasLessonsUseCase,
+) {
+
+    suspend operator fun invoke(
+        student: Student,
+        semester: Semester,
+        currentDate: LocalDate = LocalDate.now(),
+    ): Boolean {
+        val lessons = timetableRepository.getTimetable(
+            student = student,
+            semester = semester,
+            start = currentDate.monday,
+            end = currentDate.sunday,
+            forceRefresh = false,
+            timetableType = TimetableRepository.TimetableType.NORMAL
+        ).toFirstResult().dataOrNull?.lessons.orEmpty()
+        return isWeekendHasLessonsUseCase(lessons)
+    }
+}

--- a/app/src/main/java/io/github/wulkanowy/domain/timetable/IsWeekendHasLessonsUseCase.kt
+++ b/app/src/main/java/io/github/wulkanowy/domain/timetable/IsWeekendHasLessonsUseCase.kt
@@ -1,0 +1,17 @@
+package io.github.wulkanowy.domain.timetable
+
+import io.github.wulkanowy.data.db.entities.Timetable
+import java.time.DayOfWeek
+import javax.inject.Inject
+
+class IsWeekendHasLessonsUseCase @Inject constructor() {
+
+    operator fun invoke(
+        lessons: List<Timetable>,
+    ): Boolean = lessons.any {
+        it.date.dayOfWeek in listOf(
+            DayOfWeek.SATURDAY,
+            DayOfWeek.SUNDAY,
+        )
+    }
+}

--- a/app/src/main/java/io/github/wulkanowy/ui/modules/dashboard/DashboardPresenter.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/dashboard/DashboardPresenter.kt
@@ -5,6 +5,7 @@ import io.github.wulkanowy.data.dataOrNull
 import io.github.wulkanowy.data.db.entities.AdminMessage
 import io.github.wulkanowy.data.db.entities.LuckyNumber
 import io.github.wulkanowy.data.db.entities.Student
+import io.github.wulkanowy.data.db.entities.Timetable
 import io.github.wulkanowy.data.enums.MessageFolder
 import io.github.wulkanowy.data.enums.MessageType
 import io.github.wulkanowy.data.errorOrNull
@@ -23,12 +24,15 @@ import io.github.wulkanowy.data.repositories.SchoolAnnouncementRepository
 import io.github.wulkanowy.data.repositories.SemesterRepository
 import io.github.wulkanowy.data.repositories.StudentRepository
 import io.github.wulkanowy.data.repositories.TimetableRepository
+import io.github.wulkanowy.data.toFirstResult
 import io.github.wulkanowy.domain.adminmessage.GetAppropriateAdminMessageUseCase
 import io.github.wulkanowy.ui.base.BasePresenter
 import io.github.wulkanowy.ui.base.ErrorHandler
 import io.github.wulkanowy.utils.AdsHelper
 import io.github.wulkanowy.utils.calculatePercentage
+import io.github.wulkanowy.utils.monday
 import io.github.wulkanowy.utils.nextOrSameSchoolDay
+import io.github.wulkanowy.utils.sunday
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
@@ -43,6 +47,7 @@ import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import java.time.DayOfWeek
 import java.time.Instant
 import java.time.LocalDate
 import javax.inject.Inject
@@ -435,13 +440,25 @@ class DashboardPresenter @Inject constructor(
     private fun loadLessons(student: Student, forceRefresh: Boolean) {
         flatResourceFlow {
             val semester = semesterRepository.getCurrentSemester(student)
-            val date = LocalDate.now().nextOrSameSchoolDay
+
+            val currentWeekLessons = timetableRepository.getTimetable(
+                student = student,
+                semester = semester,
+                start = LocalDate.now().monday,
+                end = LocalDate.now().sunday,
+                forceRefresh = false,
+            ).toFirstResult().dataOrNull?.lessons.orEmpty()
+
+            val date = when (isWeekendHasLessons(currentWeekLessons)) {
+                true -> LocalDate.now()
+                else -> LocalDate.now().nextOrSameSchoolDay
+            }
 
             timetableRepository.getTimetable(
                 student = student,
                 semester = semester,
                 start = date,
-                end = date,
+                end = date.plusDays(1),
                 forceRefresh = forceRefresh
             )
         }
@@ -477,6 +494,15 @@ class DashboardPresenter @Inject constructor(
                 }
             }
             .launchWithUniqueRefreshJob("dashboard_lessons", forceRefresh)
+    }
+
+    private fun isWeekendHasLessons(
+        lessons: List<Timetable>,
+    ): Boolean = lessons.any {
+        it.date.dayOfWeek in listOf(
+            DayOfWeek.SATURDAY,
+            DayOfWeek.SUNDAY,
+        )
     }
 
     private fun loadHomework(student: Student, forceRefresh: Boolean) {

--- a/app/src/main/java/io/github/wulkanowy/ui/modules/dashboard/DashboardPresenter.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/dashboard/DashboardPresenter.kt
@@ -5,7 +5,6 @@ import io.github.wulkanowy.data.dataOrNull
 import io.github.wulkanowy.data.db.entities.AdminMessage
 import io.github.wulkanowy.data.db.entities.LuckyNumber
 import io.github.wulkanowy.data.db.entities.Student
-import io.github.wulkanowy.data.db.entities.Timetable
 import io.github.wulkanowy.data.enums.MessageFolder
 import io.github.wulkanowy.data.enums.MessageType
 import io.github.wulkanowy.data.errorOrNull
@@ -24,13 +23,12 @@ import io.github.wulkanowy.data.repositories.SchoolAnnouncementRepository
 import io.github.wulkanowy.data.repositories.SemesterRepository
 import io.github.wulkanowy.data.repositories.StudentRepository
 import io.github.wulkanowy.data.repositories.TimetableRepository
-import io.github.wulkanowy.data.toFirstResult
 import io.github.wulkanowy.domain.adminmessage.GetAppropriateAdminMessageUseCase
+import io.github.wulkanowy.domain.timetable.IsStudentHasLessonsOnWeekendUseCase
 import io.github.wulkanowy.ui.base.BasePresenter
 import io.github.wulkanowy.ui.base.ErrorHandler
 import io.github.wulkanowy.utils.AdsHelper
 import io.github.wulkanowy.utils.calculatePercentage
-import io.github.wulkanowy.utils.monday
 import io.github.wulkanowy.utils.nextOrSameSchoolDay
 import io.github.wulkanowy.utils.sunday
 import kotlinx.coroutines.flow.Flow
@@ -47,7 +45,6 @@ import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import timber.log.Timber
-import java.time.DayOfWeek
 import java.time.Instant
 import java.time.LocalDate
 import javax.inject.Inject
@@ -61,6 +58,7 @@ class DashboardPresenter @Inject constructor(
     private val messageRepository: MessageRepository,
     private val attendanceSummaryRepository: AttendanceSummaryRepository,
     private val timetableRepository: TimetableRepository,
+    private val isStudentHasLessonsOnWeekendUseCase: IsStudentHasLessonsOnWeekendUseCase,
     private val homeworkRepository: HomeworkRepository,
     private val examRepository: ExamRepository,
     private val conferenceRepository: ConferenceRepository,
@@ -440,16 +438,7 @@ class DashboardPresenter @Inject constructor(
     private fun loadLessons(student: Student, forceRefresh: Boolean) {
         flatResourceFlow {
             val semester = semesterRepository.getCurrentSemester(student)
-
-            val currentWeekLessons = timetableRepository.getTimetable(
-                student = student,
-                semester = semester,
-                start = LocalDate.now().monday,
-                end = LocalDate.now().sunday,
-                forceRefresh = false,
-            ).toFirstResult().dataOrNull?.lessons.orEmpty()
-
-            val date = when (isWeekendHasLessons(currentWeekLessons)) {
+            val date = when (isStudentHasLessonsOnWeekendUseCase(student, semester)) {
                 true -> LocalDate.now()
                 else -> LocalDate.now().nextOrSameSchoolDay
             }
@@ -458,8 +447,8 @@ class DashboardPresenter @Inject constructor(
                 student = student,
                 semester = semester,
                 start = date,
-                end = date.plusDays(1),
-                forceRefresh = forceRefresh
+                end = date.sunday,
+                forceRefresh = forceRefresh,
             )
         }
             .onEach {
@@ -494,15 +483,6 @@ class DashboardPresenter @Inject constructor(
                 }
             }
             .launchWithUniqueRefreshJob("dashboard_lessons", forceRefresh)
-    }
-
-    private fun isWeekendHasLessons(
-        lessons: List<Timetable>,
-    ): Boolean = lessons.any {
-        it.date.dayOfWeek in listOf(
-            DayOfWeek.SATURDAY,
-            DayOfWeek.SUNDAY,
-        )
     }
 
     private fun loadHomework(student: Student, forceRefresh: Boolean) {

--- a/app/src/main/java/io/github/wulkanowy/ui/modules/timetable/TimetablePresenter.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/timetable/TimetablePresenter.kt
@@ -21,7 +21,6 @@ import io.github.wulkanowy.data.repositories.SemesterRepository
 import io.github.wulkanowy.data.repositories.StudentRepository
 import io.github.wulkanowy.data.repositories.TimetableRepository
 import io.github.wulkanowy.data.toFirstResult
-import io.github.wulkanowy.data.waitForResult
 import io.github.wulkanowy.ui.base.BasePresenter
 import io.github.wulkanowy.ui.base.ErrorHandler
 import io.github.wulkanowy.utils.AnalyticsHelper
@@ -38,7 +37,6 @@ import io.github.wulkanowy.utils.previousSchoolDay
 import io.github.wulkanowy.utils.sunday
 import io.github.wulkanowy.utils.toFormattedString
 import io.github.wulkanowy.utils.until
-import kotlinx.coroutines.flow.firstOrNull
 import timber.log.Timber
 import java.time.DayOfWeek
 import java.time.Instant

--- a/app/src/main/java/io/github/wulkanowy/ui/modules/timetable/TimetablePresenter.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/timetable/TimetablePresenter.kt
@@ -2,7 +2,6 @@ package io.github.wulkanowy.ui.modules.timetable
 
 import android.os.Handler
 import android.os.Looper
-import io.github.wulkanowy.data.dataOrNull
 import io.github.wulkanowy.data.db.entities.Semester
 import io.github.wulkanowy.data.db.entities.Student
 import io.github.wulkanowy.data.db.entities.Timetable
@@ -20,7 +19,8 @@ import io.github.wulkanowy.data.repositories.PreferencesRepository
 import io.github.wulkanowy.data.repositories.SemesterRepository
 import io.github.wulkanowy.data.repositories.StudentRepository
 import io.github.wulkanowy.data.repositories.TimetableRepository
-import io.github.wulkanowy.data.toFirstResult
+import io.github.wulkanowy.domain.timetable.IsStudentHasLessonsOnWeekendUseCase
+import io.github.wulkanowy.domain.timetable.IsWeekendHasLessonsUseCase
 import io.github.wulkanowy.ui.base.BasePresenter
 import io.github.wulkanowy.ui.base.ErrorHandler
 import io.github.wulkanowy.utils.AnalyticsHelper
@@ -30,15 +30,12 @@ import io.github.wulkanowy.utils.isHolidays
 import io.github.wulkanowy.utils.isJustFinished
 import io.github.wulkanowy.utils.isShowTimeUntil
 import io.github.wulkanowy.utils.left
-import io.github.wulkanowy.utils.monday
 import io.github.wulkanowy.utils.nextOrSameSchoolDay
 import io.github.wulkanowy.utils.nextSchoolDay
 import io.github.wulkanowy.utils.previousSchoolDay
-import io.github.wulkanowy.utils.sunday
 import io.github.wulkanowy.utils.toFormattedString
 import io.github.wulkanowy.utils.until
 import timber.log.Timber
-import java.time.DayOfWeek
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDate.now
@@ -52,6 +49,8 @@ class TimetablePresenter @Inject constructor(
     errorHandler: ErrorHandler,
     studentRepository: StudentRepository,
     private val timetableRepository: TimetableRepository,
+    private val isStudentHasLessonsOnWeekendUseCase: IsStudentHasLessonsOnWeekendUseCase,
+    private val isWeekendHasLessonsUseCase: IsWeekendHasLessonsUseCase,
     private val semesterRepository: SemesterRepository,
     private val prefRepository: PreferencesRepository,
     private val analytics: AnalyticsHelper,
@@ -163,7 +162,7 @@ class TimetablePresenter @Inject constructor(
         }
             .logResourceStatus("load timetable data")
             .onResourceData {
-                isWeekendHasLessons = isWeekendHasLessons || isWeekendHasLessons(it.lessons)
+                isWeekendHasLessons = isWeekendHasLessons || isWeekendHasLessonsUseCase(it.lessons)
 
                 view?.run {
                     enableSwipe(true)
@@ -197,30 +196,13 @@ class TimetablePresenter @Inject constructor(
 
     private suspend fun checkInitialAndCurrentDate(student: Student, semester: Semester) {
         if (initialDate == null) {
-            val lessons = timetableRepository.getTimetable(
-                student = student,
-                semester = semester,
-                start = now().monday,
-                end = now().sunday,
-                forceRefresh = false,
-                timetableType = TimetableRepository.TimetableType.NORMAL
-            ).toFirstResult().dataOrNull?.lessons.orEmpty()
-            isWeekendHasLessons = isWeekendHasLessons(lessons)
+            isWeekendHasLessons = isStudentHasLessonsOnWeekendUseCase(student, semester)
             initialDate = getInitialDate(semester)
         }
 
         if (currentDate == null) {
             currentDate = initialDate
         }
-    }
-
-    private fun isWeekendHasLessons(
-        lessons: List<Timetable>,
-    ): Boolean = lessons.any {
-        it.date.dayOfWeek in listOf(
-            DayOfWeek.SATURDAY,
-            DayOfWeek.SUNDAY,
-        )
     }
 
     private fun getInitialDate(semester: Semester): LocalDate {


### PR DESCRIPTION
Fixes #2414

Te zmiany biorą pod uwagę to, co nieudolnie próbowałem rozwiązać już przy okazji dwóch poprzednich modyfikacji ładowania lekcji do tego kafelka, tj. lekcje w weekend.

Od teraz apka na samym początku ładowania kafelka będzie rozstrzygać na podstawie dostępnych danych, czy jakiekolwiek lekcje się w weekend odbywają i jeśli tak, to bieżącą datą, od której apka będzie szukać lekcji będzie bieżący dzień (czyli np. piątek, sobota, niedziela). Jeśli jednak żadnych lekcji nie znajdzie, to od razu załaduje kolejny tydzień.

Dzięki takiemu podejściu uczniowie w szkołach weekendowych będą mieli funkcjonalny widget w weekend, a uczniowie _zwykłych_ szkół będą wiedzieć na kafelku lekcje na poniedziałek, gdy otworzą apkę w niedzielę.

Takie rozróżnienie jest potrzebne, bo nie możemy łatwo pobierać lekcji, kiedy zakres zaczyna się od np. soboty a kończy na poniedziałku, bo repo głupieje i potrafi kasować lekcje na poniedziałek z bazy