### PR TITLE
Fix loading timetable and attendance when should be refreshed returns true

### DIFF
--- a/app/src/main/java/io/github/wulkanowy/data/db/dao/TimetableDao.kt
+++ b/app/src/main/java/io/github/wulkanowy/data/db/dao/TimetableDao.kt
@@ -15,5 +15,5 @@ interface TimetableDao : BaseDao<Timetable> {
     fun loadAll(diaryId: Int, studentId: Int, from: LocalDate, end: LocalDate): Flow<List<Timetable>>
 
     @Query("SELECT * FROM Timetable WHERE diary_id = :diaryId AND student_id = :studentId AND date >= :from AND date <= :end")
-    fun load(diaryId: Int, studentId: Int, from: LocalDate, end: LocalDate): List<Timetable>
+    suspend fun load(diaryId: Int, studentId: Int, from: LocalDate, end: LocalDate): List<Timetable>
 }

--- a/app/src/main/java/io/github/wulkanowy/data/repositories/AttendanceRepository.kt
+++ b/app/src/main/java/io/github/wulkanowy/data/repositories/AttendanceRepository.kt
@@ -16,10 +16,8 @@ import io.github.wulkanowy.utils.monday
 import io.github.wulkanowy.utils.sunday
 import io.github.wulkanowy.utils.switchSemester
 import io.github.wulkanowy.utils.uniqueSubtract
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -58,11 +56,9 @@ class AttendanceRepository @Inject constructor(
             attendanceDb.loadAll(semester.diaryId, semester.studentId, start.monday, end.sunday)
         },
         fetch = {
-            val lessons = withContext(Dispatchers.IO) {
-                timetableDb.load(
-                    semester.diaryId, semester.studentId, start.monday, end.sunday
-                )
-            }
+            val lessons = timetableDb.load(
+                semester.diaryId, semester.studentId, start.monday, end.sunday
+            )
             sdk.init(student)
                 .switchSemester(semester)
                 .getAttendance(start.monday, end.sunday)

--- a/app/src/main/java/io/github/wulkanowy/data/repositories/TimetableRepository.kt
+++ b/app/src/main/java/io/github/wulkanowy/data/repositories/TimetableRepository.kt
@@ -3,13 +3,23 @@ package io.github.wulkanowy.data.repositories
 import io.github.wulkanowy.data.db.dao.TimetableAdditionalDao
 import io.github.wulkanowy.data.db.dao.TimetableDao
 import io.github.wulkanowy.data.db.dao.TimetableHeaderDao
-import io.github.wulkanowy.data.db.entities.*
+import io.github.wulkanowy.data.db.entities.Semester
+import io.github.wulkanowy.data.db.entities.Student
+import io.github.wulkanowy.data.db.entities.Timetable
+import io.github.wulkanowy.data.db.entities.TimetableAdditional
+import io.github.wulkanowy.data.db.entities.TimetableHeader
 import io.github.wulkanowy.data.mappers.mapToEntities
 import io.github.wulkanowy.data.networkBoundResource
 import io.github.wulkanowy.data.pojos.TimetableFull
 import io.github.wulkanowy.sdk.Sdk
 import io.github.wulkanowy.services.alarm.TimetableNotificationSchedulerHelper
-import io.github.wulkanowy.utils.*
+import io.github.wulkanowy.utils.AutoRefreshHelper
+import io.github.wulkanowy.utils.getRefreshKey
+import io.github.wulkanowy.utils.init
+import io.github.wulkanowy.utils.monday
+import io.github.wulkanowy.utils.sunday
+import io.github.wulkanowy.utils.switchSemester
+import io.github.wulkanowy.utils.uniqueSubtract
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.sync.Mutex
@@ -121,12 +131,12 @@ class TimetableRepository @Inject constructor(
         }
     }
 
-    fun getTimetableFromDatabase(
+    suspend fun getTimetableFromDatabase(
         semester: Semester,
-        from: LocalDate,
+        start: LocalDate,
         end: LocalDate
-    ): Flow<List<Timetable>> {
-        return timetableDb.loadAll(semester.diaryId, semester.studentId, from, end)
+    ): List<Timetable> {
+        return timetableDb.load(semester.diaryId, semester.studentId, start, end)
     }
 
     suspend fun updateTimetable(timetable: List<Timetable>) {

--- a/app/src/main/java/io/github/wulkanowy/domain/timetable/IsStudentHasLessonsOnWeekendUseCase.kt
+++ b/app/src/main/java/io/github/wulkanowy/domain/timetable/IsStudentHasLessonsOnWeekendUseCase.kt
@@ -1,10 +1,7 @@
 package io.github.wulkanowy.domain.timetable
 
-import io.github.wulkanowy.data.dataOrNull
 import io.github.wulkanowy.data.db.entities.Semester
-import io.github.wulkanowy.data.db.entities.Student
 import io.github.wulkanowy.data.repositories.TimetableRepository
-import io.github.wulkanowy.data.toFirstResult
 import io.github.wulkanowy.utils.monday
 import io.github.wulkanowy.utils.sunday
 import java.time.LocalDate
@@ -16,18 +13,14 @@ class IsStudentHasLessonsOnWeekendUseCase @Inject constructor(
 ) {
 
     suspend operator fun invoke(
-        student: Student,
         semester: Semester,
         currentDate: LocalDate = LocalDate.now(),
     ): Boolean {
-        val lessons = timetableRepository.getTimetable(
-            student = student,
+        val lessons = timetableRepository.getTimetableFromDatabase(
             semester = semester,
             start = currentDate.monday,
             end = currentDate.sunday,
-            forceRefresh = false,
-            timetableType = TimetableRepository.TimetableType.NORMAL
-        ).toFirstResult().dataOrNull?.lessons.orEmpty()
+        )
         return isWeekendHasLessonsUseCase(lessons)
     }
 }

--- a/app/src/main/java/io/github/wulkanowy/services/sync/works/TimetableWork.kt
+++ b/app/src/main/java/io/github/wulkanowy/services/sync/works/TimetableWork.kt
@@ -6,7 +6,6 @@ import io.github.wulkanowy.data.repositories.TimetableRepository
 import io.github.wulkanowy.data.waitForResult
 import io.github.wulkanowy.services.sync.notifications.ChangeTimetableNotification
 import io.github.wulkanowy.utils.nextOrSameSchoolDay
-import kotlinx.coroutines.flow.first
 import java.time.LocalDate.now
 import javax.inject.Inject
 
@@ -31,10 +30,9 @@ class TimetableWork @Inject constructor(
 
         timetableRepository.getTimetableFromDatabase(
             semester = semester,
-            from = startDate,
+            start = startDate,
             end = endDate,
         )
-            .first()
             .filterNot { it.isNotified }
             .let {
                 if (it.isNotEmpty()) changeTimetableNotification.notify(it, student)

--- a/app/src/main/java/io/github/wulkanowy/ui/modules/dashboard/DashboardPresenter.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/dashboard/DashboardPresenter.kt
@@ -438,7 +438,7 @@ class DashboardPresenter @Inject constructor(
     private fun loadLessons(student: Student, forceRefresh: Boolean) {
         flatResourceFlow {
             val semester = semesterRepository.getCurrentSemester(student)
-            val date = when (isStudentHasLessonsOnWeekendUseCase(student, semester)) {
+            val date = when (isStudentHasLessonsOnWeekendUseCase(semester)) {
                 true -> LocalDate.now()
                 else -> LocalDate.now().nextOrSameSchoolDay
             }

--- a/app/src/main/java/io/github/wulkanowy/ui/modules/timetable/TimetablePresenter.kt
+++ b/app/src/main/java/io/github/wulkanowy/ui/modules/timetable/TimetablePresenter.kt
@@ -3,7 +3,6 @@ package io.github.wulkanowy.ui.modules.timetable
 import android.os.Handler
 import android.os.Looper
 import io.github.wulkanowy.data.db.entities.Semester
-import io.github.wulkanowy.data.db.entities.Student
 import io.github.wulkanowy.data.db.entities.Timetable
 import io.github.wulkanowy.data.enums.TimetableGapsMode.BETWEEN_AND_BEFORE_LESSONS
 import io.github.wulkanowy.data.enums.TimetableGapsMode.NO_GAPS
@@ -150,7 +149,7 @@ class TimetablePresenter @Inject constructor(
             val student = studentRepository.getCurrentStudent()
             val semester = semesterRepository.getCurrentSemester(student)
 
-            checkInitialAndCurrentDate(student, semester)
+            checkInitialAndCurrentDate(semester)
             timetableRepository.getTimetable(
                 student = student,
                 semester = semester,
@@ -194,9 +193,9 @@ class TimetablePresenter @Inject constructor(
             .launch()
     }
 
-    private suspend fun checkInitialAndCurrentDate(student: Student, semester: Semester) {
+    private suspend fun checkInitialAndCurrentDate(semester: Semester) {
         if (initialDate == null) {
-            isWeekendHasLessons = isStudentHasLessonsOnWeekendUseCase(student, semester)
+            isWeekendHasLessons = isStudentHasLessonsOnWeekendUseCase(semester)
             initialDate = getInitialDate(semester)
         }
 


### PR DESCRIPTION
Problem spowodowany był tym, że apka próbowała z wyprzedzeniem (przed załadowaniem właściwych danych) określić, czy w weekend będą/były lekcje czy nie i na tej podstawie załadować odpowiedni dzień w planie lekcji oraz we frekwencji. 

Dlatego dashboard czekał na załadowanie planu lekcji tak naprawdę do samego (intermediate nie miał tu prawa zadziałać), to samo w zakładce Plan lekcji oraz we Frekwencji.
Problem pojawiał się dopiero po tym, jak minęła (domyślnie) godzina od ostatniego odświeżenia danego tygodnia

Regression from  #2326
Fixes #2432 